### PR TITLE
add dependency: jackson-datatype-joda

### DIFF
--- a/lora-ns-ttn/pom.xml
+++ b/lora-ns-ttn/pom.xml
@@ -54,6 +54,11 @@
 			<artifactId>pgv-java-stub</artifactId>
 			<version>${pgv.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-joda</artifactId>
+			<version>2.13.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
This fixes a HttpMessageConversionException error when provisionning a device on the ttn LNS. the LNS returns a value with a type org.joda.time.DateTime that was not imported