### PR TITLE
fix bad formatting for field: c8y_RequiredAvailability

### DIFF
--- a/nodejs/lora-codec-adeunis/src/index.ts
+++ b/nodejs/lora-codec-adeunis/src/index.ts
@@ -112,14 +112,14 @@ class AdeunisCodec extends DeviceCodec {
         if (result.calculatedSendingPeriod.unit === "s") {
           requiredAvailability = requiredAvailability / 60.0;
         }
-        mo["c8y_RequiredAvailability"] = requiredAvailability;
+        mo["c8y_RequiredAvailability"] = { "responseInterval": requiredAvailability}; 
       }
       if (result.transmissionPeriod) {
         let requiredAvailability: number = result.transmissionPeriod.value;
         if (result.transmissionPeriod.unit === "s") {
           requiredAvailability = requiredAvailability / 60.0;
         }
-        mo["c8y_RequiredAvailability"] = requiredAvailability;
+        mo["c8y_RequiredAvailability"] = { "responseInterval": requiredAvailability}; 
       }
       c8yData.morToUpdate = mo;
     }


### PR DESCRIPTION
[Adeunis codec] when receiving a configuration uplink frame from the device, the value of responseInterval is set as the value of the key c8y_RequiredAvailability

`"c8y_RequiredAvailability": 10`
 
It should be set as value of the subfield responseInterval
 
```
"c8y_RequiredAvailability": {
    "responseInterval": 200
}
```