### PR TITLE
Support multiple connections to Actility LNS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 web/lora-package/dist
 web/lora-package/node_modules
 c8y_credentials
+
+**/.idea/

--- a/java/lora-ns-actility/src/main/java/lora/ns/actility/common/RandomUtils.java
+++ b/java/lora-ns-actility/src/main/java/lora/ns/actility/common/RandomUtils.java
@@ -1,0 +1,19 @@
+package lora.ns.actility.common;
+
+import java.security.SecureRandom;
+import java.util.Random;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RandomUtils {
+
+    private static final String HEX_ALPHABET = "0123456789abcdef";
+    private static final Random RANDOM = new SecureRandom();
+
+    public static String generateRandomHexString(int length) {
+        return RANDOM.ints(length, 0, HEX_ALPHABET.length())
+            .mapToObj(HEX_ALPHABET::charAt)
+            .collect(StringBuilder::new, StringBuilder::append, StringBuilder::append)
+            .toString();
+    }
+}

--- a/java/lora-ns-ms/src/main/java/lora/ns/connector/LNSConnector.java
+++ b/java/lora-ns-ms/src/main/java/lora/ns/connector/LNSConnector.java
@@ -43,4 +43,8 @@ public interface LNSConnector {
 	void provisionGateway(GatewayProvisioning gatewayProvisioning);
 
 	void deprovisionGateway(String id);
+
+	default Properties getInitProperties() {
+		return new Properties();
+	}
 }


### PR DESCRIPTION
Resolves #103 

### Purpose
Allow multiple connections to the same Actility LNS. Currently, `asId` and `asKey` are hardcoded and at a second connection creation attempt, LNS API returns 409.

### Brief change log
* At Actility connection creation, generate `asId` and `adKey` and save them as config properties
* Whenever above values are needed, take them from config properties
* If config propeties are missing, use the previously hardcoded values (for backward compatibility)
