### PR TITLE
Allow webhook URL customization

### DIFF
--- a/java/lora-ns-actility/src/main/java/lora/ns/actility/ActilityConnector.java
+++ b/java/lora-ns-actility/src/main/java/lora/ns/actility/ActilityConnector.java
@@ -1,5 +1,7 @@
 package lora.ns.actility;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.math.BigDecimal;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
@@ -7,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 import javax.net.ssl.HostnameVerifier;
@@ -272,6 +275,13 @@ public class ActilityConnector extends LNSAbstractConnector {
 			}
 			this.appServerId = appServerApi.createAppServer(appServer).getID();
 		}
+	}
+
+	@Override
+	public Optional<String> getCustomRoutingBaseUrl() {
+		return isNotBlank(properties.getProperty("webhook-url")) ?
+				Optional.of(properties.getProperty("webhook-url")) :
+				super.getCustomRoutingBaseUrl();
 	}
 
 	@Override

--- a/java/lora-ns-actility/src/main/java/lora/ns/actility/ConnectorWizardStep1.java
+++ b/java/lora-ns-actility/src/main/java/lora/ns/actility/ConnectorWizardStep1.java
@@ -1,27 +1,18 @@
 package lora.ns.actility;
 
-import java.util.LinkedList;
 import java.util.List;
-
 import lora.ns.connector.LNSConnectorWizardStep;
 import lora.ns.connector.PropertyDescription;
-import lora.ns.connector.PropertyDescription.PropertyType;
 
 public class ConnectorWizardStep1 implements LNSConnectorWizardStep {
 
-	protected LinkedList<PropertyDescription> propertyDescriptions = new LinkedList<>();
-	{
-		propertyDescriptions.add(new PropertyDescription("url", "URL", true, null, null, null, null, null, null, null,
-						PropertyType.TEXT, false));
-		propertyDescriptions.add(new PropertyDescription("username", "Username", true, null, null, null, null, null,
-						null, null, PropertyType.TEXT, false));
-		propertyDescriptions.add(new PropertyDescription("password", "Password", true, null, null, null, null, null,
-						null, null, PropertyType.PASSWORD, true));
-		propertyDescriptions.add(new PropertyDescription("domain", "Domain", false, null, null, null, null, null, null,
-						null, PropertyType.TEXT, false));
-		propertyDescriptions.add(new PropertyDescription("group", "Group", false, null, null, null, null, null, null,
-						null, PropertyType.TEXT, false));
-	}
+	protected List<PropertyDescription> propertyDescriptions = List.of(
+			PropertyDescription.text("url", "URL", true),
+			PropertyDescription.text("username", "Username", true),
+			PropertyDescription.password("password", "Password"),
+			PropertyDescription.text("domain", "Domain", false),
+			PropertyDescription.text("group", "Group", false),
+			PropertyDescription.text("webhook-url", "Webhook URL", false));
 
 	@Override
 	public String getName() {

--- a/java/lora-ns-liveobjects/src/main/java/lora/ns/liveobjects/ConnectorWizardStep1.java
+++ b/java/lora-ns-liveobjects/src/main/java/lora/ns/liveobjects/ConnectorWizardStep1.java
@@ -9,7 +9,8 @@ class ConnectorWizardStep1 implements LNSConnectorWizardStep {
     private final List<PropertyDescription> propertyDescriptions = List.of(
             PropertyDescription.text("apikey", "API Key", true).withEncrypted(true),
             PropertyDescription.text("proxy-host", "Proxy Host", false),
-            PropertyDescription.number("proxy-port", "Proxy Port", false));
+            PropertyDescription.number("proxy-port", "Proxy Port", false),
+            PropertyDescription.text("webhook-url", "Webhook URL", false));
 
     public String getName() {
         return "step1";

--- a/java/lora-ns-liveobjects/src/main/java/lora/ns/liveobjects/LiveObjectsConnector.java
+++ b/java/lora-ns-liveobjects/src/main/java/lora/ns/liveobjects/LiveObjectsConnector.java
@@ -157,6 +157,13 @@ public class LiveObjectsConnector extends LNSAbstractConnector {
 	}
 
 	@Override
+	public Optional<String> getCustomRoutingBaseUrl() {
+		return isNotBlank(properties.getProperty("webhook-url")) ?
+				Optional.of(properties.getProperty("webhook-url")) :
+				super.getCustomRoutingBaseUrl();
+	}
+
+	@Override
 	public void removeRoutings() {
 		getProperty("uplinkRouteId").ifPresent(id -> service.deleteActionPolicy(id.toString()));
 		getProperty("downlinkRouteId").ifPresent(id -> service.deleteActionPolicy(id.toString()));

--- a/java/lora-ns-ms/src/main/java/lora/ns/connector/LNSConnector.java
+++ b/java/lora-ns-ms/src/main/java/lora/ns/connector/LNSConnector.java
@@ -1,6 +1,7 @@
 package lora.ns.connector;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 import lora.codec.downlink.DownlinkData;
@@ -46,5 +47,9 @@ public interface LNSConnector {
 
 	default Properties getInitProperties() {
 		return new Properties();
+	}
+
+	default Optional<String> getCustomRoutingBaseUrl() {
+		return Optional.empty();
 	}
 }


### PR DESCRIPTION
Resolves #109.

### Purpose
Allow using custom webhook URL, other than the default domain taken from `/tenant/currentTenant` -> `domainName`. This is especially important in case of cumulocity running behind a firewall.

### Brief change log
* an optional parameter added to liveobjects & actility connection wizard: `webhook-url`
* if the parameter is defined, it's used as base url for LNS' webhooks, otherwise if behaves as previously - the base url is taken from `/tenant/currentTenant` -> `domainName`.